### PR TITLE
Add IPv6 High authentication DLMS client example

### DIFF
--- a/Gurux.DLMS.Client.Example.python/example_ipv6_high_auth.py
+++ b/Gurux.DLMS.Client.Example.python/example_ipv6_high_auth.py
@@ -1,0 +1,42 @@
+import logging
+
+from gurux_dlms import GXDLMSClient
+from gurux_dlms.enums import InterfaceType, Authentication
+from gurux_net import GXNet, NetworkType
+from gurux_common.enums import TraceLevel
+
+from GXDLMSReader import GXDLMSReader
+
+
+def main():
+    host = "[fe80::1]"  # Replace with the meter's IPv6 address
+    port = 4059
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    logging.info("Create DLMS client with High authentication")
+    client = GXDLMSClient(
+        useLogicalNameReferencing=True,
+        clientAddress=16,
+        serverAddress=1,
+        forAuthentication=Authentication.HIGH,
+        password="secret",  # Replace with your password
+        interfaceType=InterfaceType.WRAPPER,
+    )
+
+    logging.info("Create TCP/IPv6 connection to %s:%s", host, port)
+    media = GXNet(NetworkType.TCP, host, port)
+    reader = GXDLMSReader(client, media, TraceLevel.INFO, None)
+
+    try:
+        logging.info("Open connection")
+        media.open()
+        logging.info("Initialize DLMS handshake")
+        reader.initializeConnection()
+        logging.info("Connection established")
+    finally:
+        logging.info("Close connection")
+        reader.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a sample script showing how to connect using TCP/IPv6 with High authentication

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686003ea91a08330a3b4f412cd0d6956